### PR TITLE
Fix content type (it posts JSON)

### DIFF
--- a/ESPCanary.cpp
+++ b/ESPCanary.cpp
@@ -139,7 +139,7 @@ void FtpServer::handleFTP()
 				String message = "{\"ip\":\"";
 				message = message + remoteip;
 				message = message + "\"}";
-				http.addHeader("Content-Type", "text/plain");
+				http.addHeader("Content-Type", "application/json");
 				Serial.println("POSTing JSON");
 				Serial.println(message);
 


### PR DESCRIPTION
The code pushes JSON content, so let the content-type show that.

This will make it easier to pass with in-house "canary" targets.