### PR TITLE
Update ESPCanary.cpp

### DIFF
--- a/ESPCanary.cpp
+++ b/ESPCanary.cpp
@@ -161,6 +161,7 @@ void FtpServer::fireCanary()
 	Serial.println(remoteip);
 	Serial.println("Attempting Canary");
 	HTTPClient http;
+	WiFiClient wclient;
 	String token = _FTP_CAN;
 	if(_FTP_APPEND_IP){
 		token = token + _FTP_APPEND_CHAR;
@@ -168,7 +169,7 @@ void FtpServer::fireCanary()
 	}
 	Serial.print("Connecting to ");
 	Serial.println(token);
-	http.begin(token);
+	http.begin(wclient, token);
 	http.setUserAgent(remoteip);
 
 


### PR DESCRIPTION
Fixed Compilation bug of httpclient::begin line that was deprecated
info: https://community.platformio.org/t/bool-httpclient-begin-string-is-deprecated/16924

Verified and working on an ESP8266